### PR TITLE
Draft: 支持 stdio 模式下的 OAuth 回调 URL 配置

### DIFF
--- a/ENV_CONFIG.md
+++ b/ENV_CONFIG.md
@@ -1,0 +1,191 @@
+# 环境变量配置说明
+
+## 基础配置
+
+### 必需配置项
+
+```bash
+# 飞书应用配置
+FEISHU_APP_ID=cli_xxxxx          # 飞书应用 ID（必需）
+FEISHU_APP_SECRET=xxxxx          # 飞书应用密钥（必需）
+```
+
+### 可选配置项
+
+```bash
+# 服务器配置
+PORT=3333                        # 服务器端口（默认：3333）
+
+# 认证类型配置
+FEISHU_AUTH_TYPE=tenant          # 认证类型（默认：tenant）
+                                 # tenant: 应用级认证
+                                 # user: 用户级认证（需要 OAuth 授权）
+```
+
+## Stdio 模式下的特殊配置
+
+### 问题说明
+
+在 **stdio 模式**下使用 **user 认证类型**时，系统无法从 HTTP 请求中获取 `baseUrl`，导致无法生成正确的 OAuth 授权链接。
+
+### 解决方案
+
+添加 `FEISHU_CALLBACK_URL` 环境变量来指定 OAuth 回调地址：
+
+```bash
+# OAuth 回调 URL（在 stdio 模式下使用 user 认证时必需）
+FEISHU_CALLBACK_URL=http://localhost:3333/callback
+```
+
+**重要说明：**
+1. 此配置仅在 **stdio 模式** + **user 认证** 时必需
+2. 回调 URL 必须与飞书应用后台配置的 `redirect_uri` **完全一致**
+3. 如果不配置，系统会使用默认值 `http://localhost:3333/callback`
+4. 建议同时运行一个 HTTP 服务器来处理回调
+
+### 使用场景对比
+
+| 运行模式 | 认证类型 | 是否需要 FEISHU_CALLBACK_URL | 说明 |
+|---------|---------|----------------------------|------|
+| HTTP (SSE) | tenant | ❌ 不需要 | 应用级认证，无需 OAuth |
+| HTTP (SSE) | user | ❌ 不需要 | 可从 HTTP 请求中获取 baseUrl |
+| Stdio | tenant | ❌ 不需要 | 应用级认证，无需 OAuth |
+| Stdio | user | ✅ **必需** | 无法从请求中获取 baseUrl |
+
+## 完整配置示例
+
+### 示例 1：Stdio 模式 + User 认证
+
+```bash
+# .env 文件
+FEISHU_APP_ID=cli_xxxxx
+FEISHU_APP_SECRET=xxxxx
+FEISHU_AUTH_TYPE=user
+FEISHU_CALLBACK_URL=http://localhost:3333/callback
+```
+
+对应的 Cursor 配置：
+
+```json
+{
+  "mcpServers": {
+    "feishu": {
+      "command": "npx",
+      "args": ["-y", "feishu-mcp", "--stdio"],
+      "env": {
+        "FEISHU_APP_ID": "cli_xxxxx",
+        "FEISHU_APP_SECRET": "xxxxx",
+        "FEISHU_AUTH_TYPE": "user",
+        "FEISHU_CALLBACK_URL": "http://localhost:3333/callback"
+      }
+    }
+  }
+}
+```
+
+### 示例 2：HTTP 模式 + User 认证
+
+```bash
+# .env 文件
+FEISHU_APP_ID=cli_xxxxx
+FEISHU_APP_SECRET=xxxxx
+PORT=3333
+FEISHU_AUTH_TYPE=user
+# 不需要配置 FEISHU_CALLBACK_URL
+```
+
+对应的 Cursor 配置：
+
+```json
+{
+  "mcpServers": {
+    "feishu": {
+      "url": "http://localhost:3333/sse?userKey=123456"
+    }
+  }
+}
+```
+
+### 示例 3：Stdio 模式 + Tenant 认证
+
+```bash
+# .env 文件
+FEISHU_APP_ID=cli_xxxxx
+FEISHU_APP_SECRET=xxxxx
+FEISHU_AUTH_TYPE=tenant
+# 不需要配置 FEISHU_CALLBACK_URL
+```
+
+对应的 Cursor 配置：
+
+```json
+{
+  "mcpServers": {
+    "feishu": {
+      "command": "npx",
+      "args": ["-y", "feishu-mcp", "--stdio"],
+      "env": {
+        "FEISHU_APP_ID": "cli_xxxxx",
+        "FEISHU_APP_SECRET": "xxxxx",
+        "FEISHU_AUTH_TYPE": "tenant"
+      }
+    }
+  }
+}
+```
+
+## 其他可选配置
+
+```bash
+# 日志配置
+LOG_LEVEL=info                   # 日志级别（debug, info, log, warn, error, none）
+LOG_SHOW_TIMESTAMP=true          # 是否显示时间戳
+LOG_SHOW_LEVEL=true              # 是否显示日志级别
+
+# 缓存配置
+CACHE_ENABLED=true               # 是否启用缓存
+CACHE_TTL=300                    # 缓存生存时间（秒）
+CACHE_MAX_SIZE=100               # 最大缓存条目数
+```
+
+## 命令行参数
+
+除了环境变量，也可以使用命令行参数：
+
+```bash
+npx feishu-mcp \
+  --feishu-app-id=cli_xxxxx \
+  --feishu-app-secret=xxxxx \
+  --feishu-auth-type=user \
+  --feishu-callback-url=http://localhost:3333/callback \
+  --port=3333
+```
+
+命令行参数优先级高于环境变量。
+
+## 故障排查
+
+### 问题：在 stdio 模式下收到授权错误
+
+**错误信息：**
+```
+请在浏览器打开以下链接进行授权：
+[点击授权](https://accounts.feishu.cn/open-apis/authen/v1/authorize?client_id=...&redirect_uri=undefined/callback...)
+```
+
+**原因：** `baseUrl` 为空，导致 `redirect_uri` 为 `undefined/callback`
+
+**解决方案：** 添加 `FEISHU_CALLBACK_URL` 环境变量
+
+### 问题：授权后回调失败
+
+**可能原因：**
+1. `FEISHU_CALLBACK_URL` 与飞书应用后台配置的 `redirect_uri` 不一致
+2. 没有运行 HTTP 服务器来处理回调
+3. 回调地址无法访问（网络问题、防火墙等）
+
+**解决方案：**
+1. 确保 `FEISHU_CALLBACK_URL` 与飞书应用后台配置完全一致
+2. 启动一个 HTTP 服务器：`npx feishu-mcp`（不加 --stdio）
+3. 检查网络连接和防火墙设置
+

--- a/FEISHU_CONFIG.md
+++ b/FEISHU_CONFIG.md
@@ -112,7 +112,9 @@
 ![应用详情](image/appid.png)
 
 ### 六、配置cursor
-```
+
+#### HTTP 模式（SSE）
+```json
 {
   "mcpServers": {
     "feishu": {
@@ -122,6 +124,32 @@
 }
 ```
 
-### 六、注
+#### Stdio 模式
+如果使用 stdio 模式，需要配置回调 URL 用于用户授权：
+
+```json
+{
+  "mcpServers": {
+    "feishu": {
+      "command": "node",
+      "args": ["/path/to/Feishu-MCP/build/cli.js"],
+      "env": {
+        "FEISHU_APP_ID": "your_app_id",
+        "FEISHU_APP_SECRET": "your_app_secret",
+        "FEISHU_AUTH_TYPE": "user",
+        "FEISHU_CALLBACK_URL": "http://localhost:3333/callback"
+      }
+    }
+  }
+}
+```
+
+**重要说明**：
+- 在 stdio 模式下使用用户授权（`FEISHU_AUTH_TYPE=user`）时，**必须**配置 `FEISHU_CALLBACK_URL` 环境变量
+- 回调 URL 必须与飞书应用后台配置的 redirect_uri 一致
+- 如果不配置 `FEISHU_CALLBACK_URL`，系统会使用默认的 `http://localhost:3333/callback`
+- 建议同时运行一个 HTTP 服务器来处理回调，或者使用公网可访问的回调地址
+
+### 七、注
 1. 具体可参见[官方云文档常见问题](https://open.feishu.cn/document/server-docs/docs/faq)
 1. 具体可参见[知识库常见问题](https://open.feishu.cn/document/server-docs/docs/wiki-v2/wiki-qa)

--- a/README.md
+++ b/README.md
@@ -155,10 +155,13 @@ npx feishu-mcp@latest --feishu-app-id=<你的飞书应用ID> --feishu-app-secret
 | `FEISHU_APP_SECRET` | ✅ | 飞书应用密钥                                                             | - |
 | `PORT` | ❌ | 服务器端口                                                              | `3333` |
 | `FEISHU_AUTH_TYPE` | ❌ | 认证凭证类型，使用 `user`（用户级,使用时是用户的身份操作飞书文档，需OAuth授权），使用 `tenant`（应用级，默认） | `tenant` |
+| `FEISHU_CALLBACK_URL` | ❌ | OAuth 回调 URL，**在 stdio 模式下使用 `user` 认证时必需**。必须与飞书应用后台配置的 redirect_uri 一致 | `http://localhost:3333/callback` |
 
 ### 配置文件方式（适用于 Cursor、Cline 等）
 
-```
+#### Stdio 模式配置
+
+```json
 {
   "mcpServers": {
     "feishu-mcp": {
@@ -167,9 +170,24 @@ npx feishu-mcp@latest --feishu-app-id=<你的飞书应用ID> --feishu-app-secret
       "env": {
         "FEISHU_APP_ID": "<你的飞书应用ID>",
         "FEISHU_APP_SECRET": "<你的飞书应用密钥>",
-        "FEISHU_AUTH_TYPE": "<tenant/user>"
+        "FEISHU_AUTH_TYPE": "<tenant/user>",
+        "FEISHU_CALLBACK_URL": "http://localhost:3333/callback"
       }
-    },
+    }
+  }
+}
+```
+
+**⚠️ 重要提示**：
+- 使用 `FEISHU_AUTH_TYPE=user` 时，**必须**配置 `FEISHU_CALLBACK_URL`
+- 回调 URL 必须与飞书应用后台配置的 redirect_uri 完全一致
+- 建议同时运行一个 HTTP 服务器来处理回调（见下方 HTTP 模式配置）
+
+#### HTTP 模式配置（SSE）
+
+```json
+{
+  "mcpServers": {
     "feishu_local": {
       "url": "http://localhost:3333/sse?userKey=123456"
     }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -29,6 +29,7 @@ export interface FeishuConfig {
   baseUrl: string;
   authType: 'tenant' | 'user';
   tokenEndpoint: string;
+  callbackUrl?: string; // 用于stdio模式下的回调URL
 }
 
 /**
@@ -145,6 +146,10 @@ export class Config {
         'feishu-token-endpoint': {
           type: 'string',
           description: '获取token的接口地址，默认 http://localhost:3333/getToken'
+        },
+        'feishu-callback-url': {
+          type: 'string',
+          description: '飞书OAuth回调URL，用于stdio模式下的用户授权'
         }
       })
       .help()
@@ -239,6 +244,15 @@ export class Config {
       this.configSources['feishu.tokenEndpoint'] = ConfigSource.ENV;
     } else {
       this.configSources['feishu.tokenEndpoint'] = ConfigSource.DEFAULT;
+    }
+    
+    // 处理callbackUrl
+    if (argv['feishu-callback-url']) {
+      feishuConfig.callbackUrl = argv['feishu-callback-url'];
+      this.configSources['feishu.callbackUrl'] = ConfigSource.CLI;
+    } else if (process.env.FEISHU_CALLBACK_URL) {
+      feishuConfig.callbackUrl = process.env.FEISHU_CALLBACK_URL;
+      this.configSources['feishu.callbackUrl'] = ConfigSource.ENV;
     }
     
     return feishuConfig;
@@ -378,6 +392,9 @@ export class Config {
     }
     Logger.info(`- API URL: ${this.feishu.baseUrl} (来源: ${this.configSources['feishu.baseUrl']})`);
     Logger.info(`- 认证类型: ${this.feishu.authType} (来源: ${this.configSources['feishu.authType']})`);
+    if (this.feishu.callbackUrl) {
+      Logger.info(`- 回调URL: ${this.feishu.callbackUrl} (来源: ${this.configSources['feishu.callbackUrl']})`);
+    }
 
     Logger.info('日志配置:');
     Logger.info(`- 日志级别: ${LogLevel[this.log.level]} (来源: ${this.configSources['log.level']})`);


### PR DESCRIPTION
发现在stdio模式下使用user授权获取不到正确的回调地址，修复一下


- 新增 FEISHU_CALLBACK_URL 环境变量和命令行参数支持
- 修复 stdio 模式下 baseUrl 无法获取的问题
- 优化授权 URL 生成逻辑，支持多种配置方式
- 新增 ENV_CONFIG.md 详细配置文档
- 更新 README.md 和 FEISHU_CONFIG.md 文档


