### PR TITLE
fix: 修复 stdio 模式 user 认证缓存与错误分支

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ FEISHU_BASE_URL=https://open.feishu.cn/open-apis
 
 # 认证凭证类型，支持 tenant（应用级，默认）或 user（用户级，需OAuth授权）注意：只有本地运行服务时支持user凭证，否则就需要配置FEISHU_TOKEN_ENDPOINT，自己实现获取token管理（可以参考 callbackService、feishuAuthService）
 FEISHU_AUTH_TYPE=tenant # 可选值：tenant 或 user
+FEISHU_USER_KEY=stdio # stdio 模式下的用户标识，可通过 --user-key 覆盖
 
 # 启用权限检查（可以帮助我们在飞书授权不足时指导如何配置最新权限）
 FEISHU_SCOPE_VALIDATION=true

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@
 ### 方式一：使用 NPM 快速运行
 
 ```bash
-npx feishu-mcp@latest --feishu-app-id=<你的飞书应用ID> --feishu-app-secret=<你的飞书应用密钥> --feishu-auth-type=<tenant/user>
+npx feishu-mcp@latest --feishu-app-id=<你的飞书应用ID> --feishu-app-secret=<你的飞书应用密钥> --feishu-auth-type=<tenant/user> --user-key=<你的用户标识>
 ```
 
 ### 方式二：本地运行
@@ -125,6 +125,7 @@ npx feishu-mcp@latest --feishu-app-id=<你的飞书应用ID> --feishu-app-secret
    FEISHU_APP_SECRET=xxxxx
    PORT=3333
    FEISHU_AUTH_TYPE=tenant/user
+   FEISHU_USER_KEY=stdio
    ```
 
 4. **运行服务器**
@@ -160,6 +161,7 @@ npx feishu-mcp@latest --feishu-app-id=<你的飞书应用ID> --feishu-app-secret
 | `PORT` | ❌ | 服务器端口                                                              | `3333` |
 | `FEISHU_AUTH_TYPE` | ❌ | 认证凭证类型，使用 `user`（用户级,使用时是用户的身份操作飞书文档，需OAuth授权），使用 `tenant`（应用级，默认） | `tenant` |
 | `FEISHU_SCOPE_VALIDATION` | ❌ | 是否启用权限检查，设置为 `false` 可关闭权限检查（适用于仅使用部分功能的场景） | `true` |
+| `FEISHU_USER_KEY` | ❌ | `stdio` 模式的用户标识，可通过命令行参数 `--user-key` 覆盖 | `stdio` |
 
 ### 配置文件方式（适用于 Cursor、Cline 等）
 
@@ -172,7 +174,8 @@ npx feishu-mcp@latest --feishu-app-id=<你的飞书应用ID> --feishu-app-secret
       "env": {
         "FEISHU_APP_ID": "<你的飞书应用ID>",
         "FEISHU_APP_SECRET": "<你的飞书应用密钥>",
-        "FEISHU_AUTH_TYPE": "<tenant/user>"
+        "FEISHU_AUTH_TYPE": "<tenant/user>",
+        "FEISHU_USER_KEY": "<你的用户标识>"
       }
     },
     "feishu_local": {

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -120,8 +120,8 @@ export abstract class BaseApiService {
     
     if (this.isStdioMode()) {
       // stdio 模式下直接使用默认值
-      userKey = 'stdio';
       const config = Config.getInstance();
+      userKey = config.feishu.userKey || 'stdio';
       baseUrl = `http://localhost:${config.server.port}`;
     } else {
       // HTTP 模式下从 UserContextManager 读取
@@ -412,7 +412,7 @@ export abstract class BaseApiService {
       // refresh_token已过期或不存在，直接清除缓存
       Logger.warn('用户模式：refresh_token已过期，清除用户token缓存');
       tokenCacheManager.removeUserToken(clientKey);
-      return this.handleAuthFailure(true,clientKey,baseUrl,userKey);
+      return this.handleAuthFailure(false, clientKey, baseUrl, userKey);
     }
   }
 

--- a/src/utils/auth/tokenCacheManager.ts
+++ b/src/utils/auth/tokenCacheManager.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { Logger } from '../logger.js';
 
@@ -65,18 +66,43 @@ export class TokenCacheManager {
   private userTokenCacheFile: string;
   private tenantTokenCacheFile: string;
   private scopeVersionCacheFile: string;
+  private cacheDir: string;
 
   /**
    * 私有构造函数，用于单例模式
    */
   private constructor() {
     this.cache = new Map();
-    this.userTokenCacheFile = path.resolve(process.cwd(), 'user_token_cache.json');
-    this.tenantTokenCacheFile = path.resolve(process.cwd(), 'tenant_token_cache.json');
-    this.scopeVersionCacheFile = path.resolve(process.cwd(), 'scope_version_cache.json');
+    this.cacheDir = this.resolveCacheDir();
+    this.userTokenCacheFile = path.join(this.cacheDir, 'user_token_cache.json');
+    this.tenantTokenCacheFile = path.join(this.cacheDir, 'tenant_token_cache.json');
+    this.scopeVersionCacheFile = path.join(this.cacheDir, 'scope_version_cache.json');
+    Logger.info(`Token缓存目录: ${this.cacheDir}`);
     
     this.loadTokenCaches();
     this.startCacheCleanupTimer();
+  }
+
+  /**
+   * 解析并确保可写的缓存目录
+   */
+  private resolveCacheDir(): string {
+    const candidates = [
+      path.join(os.homedir(), '.cache', 'feishu-mcp'),
+      path.join(os.homedir(), '.feishu-mcp'),
+    ];
+
+    for (const dir of candidates) {
+      try {
+        fs.mkdirSync(dir, { recursive: true });
+        fs.accessSync(dir, fs.constants.R_OK | fs.constants.W_OK);
+        return dir;
+      } catch (error) {
+        Logger.warn(`缓存目录不可用，尝试下一个: ${dir}`, error);
+      }
+    }
+
+    throw new Error('无法找到可读写的缓存目录');
   }
 
   /**

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -31,6 +31,7 @@ export interface FeishuConfig {
   authType: 'tenant' | 'user';
   tokenEndpoint: string;
   enableScopeValidation: boolean; // 是否启用权限检查
+  userKey: string;
 }
 
 /**
@@ -151,6 +152,10 @@ export class Config {
         'feishu-scope-validation': {
           type: 'boolean',
           description: '是否启用权限检查，默认 true'
+        },
+        'user-key': {
+          type: 'string',
+          description: 'stdio 模式下的用户标识，默认 stdio'
         }
       })
       .help()
@@ -195,6 +200,7 @@ export class Config {
       authType: 'tenant', // 默认
       tokenEndpoint: `http://127.0.0.1:${serverConfig.port}/getToken`, // 默认动态端口
       enableScopeValidation: true, // 默认启用权限检查
+      userKey: 'stdio',
     };
     
     // 处理App ID
@@ -257,6 +263,17 @@ export class Config {
       this.configSources['feishu.enableScopeValidation'] = ConfigSource.ENV;
     } else {
       this.configSources['feishu.enableScopeValidation'] = ConfigSource.DEFAULT;
+    }
+
+    // 处理 userKey（stdio 模式使用）
+    if (argv['user-key']) {
+      feishuConfig.userKey = argv['user-key'];
+      this.configSources['feishu.userKey'] = ConfigSource.CLI;
+    } else if (process.env.FEISHU_USER_KEY) {
+      feishuConfig.userKey = process.env.FEISHU_USER_KEY;
+      this.configSources['feishu.userKey'] = ConfigSource.ENV;
+    } else {
+      this.configSources['feishu.userKey'] = ConfigSource.DEFAULT;
     }
     
     return feishuConfig;
@@ -398,6 +415,7 @@ export class Config {
     Logger.info(`- API URL: ${this.feishu.baseUrl} (来源: ${this.configSources['feishu.baseUrl']})`);
     Logger.info(`- 认证类型: ${this.feishu.authType} (来源: ${this.configSources['feishu.authType']})`);
     Logger.info(`- 启用权限检查: ${this.feishu.enableScopeValidation} (来源: ${this.configSources['feishu.enableScopeValidation']})`);
+    Logger.info(`- User Key: ${this.feishu.userKey} (来源: ${this.configSources['feishu.userKey']})`);
 
     Logger.info('日志配置:');
     Logger.info(`- 日志级别: ${LogLevel[this.log.level]} (来源: ${this.configSources['log.level']})`);


### PR DESCRIPTION
## 背景
在 `FEISHU_AUTH_TYPE=user` 且 `--stdio` 运行时，认证流程存在两个问题：

1. `TokenCacheManager` 使用 `process.cwd()` 作为 token 缓存文件目录，实际运行中 cwd 可能为不可写路径（例如 `/`），导致授权回调后 token 无法稳定落盘，表现为反复要求授权。
2. 用户 token 刷新不可用时，错误地走了 tenant 分支：`handleAuthFailure(true, ...)`，导致用户模式下异常提示与处理不正确。

## 修改内容
1. 调整 token 缓存目录选择逻辑，仅使用以下两个可写目录并按顺序回退：
   - `~/.cache/feishu-mcp`
   - `~/.feishu-mcp`
2. 修复用户模式失效分支调用：
   - `handleAuthFailure(true, ...)` -> `handleAuthFailure(false, ...)`

## 补充改动
1. 新增 `stdio` 用户标识可配置能力：
   - 支持环境变量：`FEISHU_USER_KEY`
   - 支持命令行参数：`--user-key`
   - 优先级：`--user-key` > `FEISHU_USER_KEY` > 默认值 `stdio`
2. `stdio` 请求上下文增加兜底：
   - `userKey = config.feishu.userKey || 'stdio'`

## 影响范围
- 主要涉及：
  - `src/utils/auth/tokenCacheManager.ts`
  - `src/utils/config.ts`
  - `src/services/baseService.ts`
  - `.env.example`
  - `README.md`
- 不改变既有接口协议，修复与增强仅针对 `user + stdio` 认证稳定性和可配置性。

## 验证
1. 本地 `build` 通过：`pnpm run build`
2. 使用 `node dist/cli.js --stdio` 启动后，授权信息可写入用户目录缓存文件（不再依赖 cwd）
3. 用户 token 过期且无法刷新时，走用户认证引导分支，不再误走 tenant 分支
4. 可通过 `FEISHU_USER_KEY` 或 `--user-key` 指定并覆盖 `stdio` 模式 userKey
