### PR TITLE
 /mcp的请求处理

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -134,8 +134,17 @@ export class FeishuMcpServer {
           return
         }
 
-        // Handle the request
-        await transport.handleRequest(req, res, req.body)
+        // 获取 baseUrl 并在用户上下文中处理请求
+        const baseUrl = getBaseUrl(req);
+        const userKey = sessionId || 'http-client';
+        
+        // Handle the request with user context
+        await this.userContextManager.run(
+          { userKey, baseUrl },
+          async () => {
+            await transport.handleRequest(req, res, req.body)
+          }
+        );
       } catch (error) {
         Logger.error('Error handling MCP request:', error)
         if (!res.headersSent) {
@@ -162,7 +171,17 @@ export class FeishuMcpServer {
         }
 
         const transport = transports[sessionId]
-        await transport.handleRequest(req, res)
+        
+        // 获取 baseUrl 并在用户上下文中处理请求
+        const baseUrl = getBaseUrl(req);
+        const userKey = sessionId || 'http-client';
+        
+        await this.userContextManager.run(
+          { userKey, baseUrl },
+          async () => {
+            await transport.handleRequest(req, res)
+          }
+        );
       } catch (error) {
         Logger.error('Error handling GET request:', error)
         if (!res.headersSent) {
@@ -181,7 +200,17 @@ export class FeishuMcpServer {
         }
 
         const transport = transports[sessionId]
-        await transport.handleRequest(req, res)
+        
+        // 获取 baseUrl 并在用户上下文中处理请求
+        const baseUrl = getBaseUrl(req);
+        const userKey = sessionId || 'http-client';
+        
+        await this.userContextManager.run(
+          { userKey, baseUrl },
+          async () => {
+            await transport.handleRequest(req, res)
+          }
+        );
 
         // Clean up resources after session termination
         if (transport.sessionId) {


### PR DESCRIPTION
当 MCP 请求通过 HTTP 模式处理时：BaseApiService 中的 request 方法会尝试从 UserContextManager 获取 baseUrl，由于没有注入上下文，userContextManager.getBaseUrl() 返回空字符串，生成的 redirect_uri 就变成了 http://localhost:port/callback（没有域名），飞书授权时 redirect_uri 不匹配，导致授权失败。需要在 /mcp 端点的 POST 和 GET 请求处理中添加 userContextManager.run 的上下文注入。