### PR TITLE
feat: add configurable redirect URI for OAuth callback

### DIFF
--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -427,9 +427,9 @@ export abstract class BaseApiService {
    */
   private generateUserAuthUrl(baseUrl: string, userKey: string): string {
     const config = Config.getInstance();
-    const { appId, appSecret } = config.feishu;
+    const { appId, appSecret, redirectUri } = config.feishu;
     const clientKey = AuthUtils.generateClientKey(userKey);
-    const redirect_uri = `${baseUrl}/callback`;
+    const redirect_uri = redirectUri || `${baseUrl}/callback`;
     const authType = config.feishu.authType;
     const enabledIds = config.features.enabledModules;
     const effectiveModules = ModuleRegistry.getEnabledModules(enabledIds, authType).map(m => m.id);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -33,6 +33,7 @@ export interface FeishuConfig {
   tokenEndpoint: string;
   enableScopeValidation: boolean; // 是否启用权限检查
   userKey: string;
+  redirectUri?: string; // 自定义 OAuth 回调地址（可选）
 }
 
 /**
@@ -173,6 +174,10 @@ export class Config {
         'enabled-modules': {
           type: 'string',
           description: '启用的功能模块列表（逗号分隔），可选值: document,task,calendar 或 all，默认 document'
+        },
+        'feishu-redirect-uri': {
+          type: 'string',
+          description: '自定义 OAuth 回调地址（默认 http://localhost:${port}/callback）'
         }
       })
       .help()
@@ -292,7 +297,16 @@ export class Config {
     } else {
       this.configSources['feishu.userKey'] = ConfigSource.DEFAULT;
     }
-    
+
+    // 处理 redirectUri（自定义 OAuth 回调地址）
+    if (argv['feishu-redirect-uri']) {
+      feishuConfig.redirectUri = argv['feishu-redirect-uri'];
+      this.configSources['feishu.redirectUri'] = ConfigSource.CLI;
+    } else if (process.env.FEISHU_REDIRECT_URI) {
+      feishuConfig.redirectUri = process.env.FEISHU_REDIRECT_URI;
+      this.configSources['feishu.redirectUri'] = ConfigSource.ENV;
+    }
+
     return feishuConfig;
   }
   


### PR DESCRIPTION
Add --feishu-redirect-uri CLI option and FEISHU_REDIRECT_URI env var to support custom OAuth callback URLs.

This allows users to configure a public domain and authorize directly from Feishu chat window, without being limited to local network environment.

Usage:
- CLI: --feishu-redirect-uri https://example.com/callback
- Env: FEISHU_REDIRECT_URI=https://example.com/callback

Changes:
- src/utils/config.ts: add redirectUri config option
- src/services/baseService.ts: use configured redirectUri

Backward compatible: Falls back to localhost when not specified.