### PR TITLE
增加飞书认证地址配置项

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 FEISHU_APP_ID=your_feishu_app_id_here
 FEISHU_APP_SECRET=your_feishu_app_secret_here
 FEISHU_BASE_URL=https://open.feishu.cn/open-apis
+FEISHU_AUTH_BASE_URL=https://accounts.feishu.cn # 飞书授权页面域名，Lark 国际版可配置为 https://accounts.larksuite.com
 
 # 认证凭证类型，支持 tenant（应用级，默认）或 user（用户级，需OAuth授权）注意：只有本地运行服务时支持user凭证，否则就需要配置FEISHU_TOKEN_ENDPOINT，自己实现获取token管理（可以参考 callbackService、feishuAuthService）
 FEISHU_AUTH_TYPE=tenant # 可选值：tenant 或 user

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ npx feishu-mcp@latest --feishu-app-id=<你的飞书应用ID> --feishu-app-secret
    PORT=3333
    FEISHU_AUTH_TYPE=tenant/user
    FEISHU_ENABLED_MODULES=document,task
+   FEISHU_AUTH_BASE_URL=https://accounts.feishu.cn  # 可选，飞书授权页面域名，Lark 国际版设置为 https://accounts.larksuite.com
    ```
 
 4. **运行服务器**
@@ -223,6 +224,8 @@ feishu-tool create_feishu_document '{"title": "测试文档"}'
 | `FEISHU_APP_ID` | ✅ | 飞书应用 ID                                                            | - |
 | `FEISHU_APP_SECRET` | ✅ | 飞书应用密钥                                                             | - |
 | `PORT` | ❌ | 服务器端口                                                              | `3333` |
+| `FEISHU_BASE_URL` | ❌ | 飞书 API 基础 URL，Lark 国际版可配置为 `https://open.larksuite.com/open-apis` | `https://open.feishu.cn/open-apis` |
+| `FEISHU_AUTH_BASE_URL` | ❌ | 飞书授权页面域名，Lark 国际版设置为 `https://accounts.larksuite.com` | `https://accounts.feishu.cn` |
 | `FEISHU_AUTH_TYPE` | ❌ | 认证凭证类型，使用 `user`（用户级,使用时是用户的身份操作飞书文档，需OAuth授权），使用 `tenant`（应用级，默认） | `tenant` |
 | `FEISHU_SCOPE_VALIDATION` | ❌ | 是否启用权限检查，设置为 `false` 可关闭权限检查（适用于仅使用部分功能的场景） | `true` |
 | `FEISHU_ENABLED_MODULES` | ❌ | 启用模块：`document`、`task`、`calendar`、`member`、`all`。task/calendar/member 需 user 认证 | `document` |
@@ -240,6 +243,8 @@ feishu-tool create_feishu_document '{"title": "测试文档"}'
 
 ### 配置文件方式（适用于 Cursor、Cline 等）
 
+#### stdio 模式（推荐）
+
 ```
 {
   "mcpServers": {
@@ -253,7 +258,16 @@ feishu-tool create_feishu_document '{"title": "测试文档"}'
         "FEISHU_ENABLED_MODULES": "document,task",
         "FEISHU_USER_KEY": "<你的用户标识>"
       }
-    },
+    }
+  }
+}
+```
+
+#### SSE 模式
+
+```
+{
+  "mcpServers": {
     "feishu_local": {
       "url": "http://localhost:3333/sse?userKey=123456"
     }
@@ -261,7 +275,26 @@ feishu-tool create_feishu_document '{"title": "测试文档"}'
 }
 ```
 
-**⚠️ 重要提示** : `http://localhost:3333/sse?userKey=123456` 中userKey表示连接用户的标识，是非常重要的配置，请填写并尽可能随机
+#### HTTP Streamable 模式（MCP 2025-03-26 规范）
+
+从版本 0.2.x 开始，支持 MCP 协议最新的 HTTP Streamable 传输方式：
+
+```
+{
+  "mcpServers": {
+    "feishu_streamable": {
+      "url": "http://localhost:3333/mcp?userKey=123456"
+    }
+  }
+}
+```
+
+**HTTP Streamable 特点**：
+- 符合 MCP 2025-03-26 最新规范
+- 支持无状态请求和有状态会话两种模式
+- 更好的兼容性和性能
+
+**⚠️ 重要提示** : URL 中的 `userKey` 表示连接用户的标识，是非常重要的配置，请填写并尽可能随机
 
 **userKey 传递方式**：支持两种方式传递用户标识
 - **URL 查询参数**：`?userKey=123456`（推荐，配置简单）

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -92,7 +92,7 @@ async function waitForToken(clientKey: string, timeoutMs: number): Promise<boole
  */
 export async function handleAuthRequired(userKey: string): Promise<void> {
   const config = Config.getInstance();
-  const { appId, appSecret } = config.feishu;
+  const { appId, appSecret, authBaseUrl } = config.feishu;
 
   // 1. 寻找可用端口（从配置端口开始）
   const port = await findAvailablePort(config.server.port);
@@ -109,7 +109,7 @@ export async function handleAuthRequired(userKey: string): Promise<void> {
 
   // 3. 构造飞书 OAuth 授权 URL（与 baseService.generateUserAuthUrl 保持一致）
   const authUrl =
-    `https://accounts.feishu.cn/open-apis/authen/v1/authorize` +
+    `${authBaseUrl}/open-apis/authen/v1/authorize` +
     `?client_id=${encodeURIComponent(appId)}` +
     `&redirect_uri=${encodeURIComponent(redirectUri)}` +
     `&scope=${scope}` +

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -427,7 +427,7 @@ export abstract class BaseApiService {
    */
   private generateUserAuthUrl(baseUrl: string, userKey: string): string {
     const config = Config.getInstance();
-    const { appId, appSecret } = config.feishu;
+    const { appId, appSecret, authBaseUrl } = config.feishu;
     const clientKey = AuthUtils.generateClientKey(userKey);
     const redirect_uri = `${baseUrl}/callback`;
     const authType = config.feishu.authType;
@@ -438,6 +438,6 @@ export abstract class BaseApiService {
     const scope = encodeURIComponent(scopeList.join(' '));
     const state = AuthUtils.encodeState(appId, appSecret, clientKey, redirect_uri);
 
-    return `https://accounts.feishu.cn/open-apis/authen/v1/authorize?client_id=${appId}&redirect_uri=${encodeURIComponent(redirect_uri)}&scope=${scope}&state=${state}`;
+    return `${authBaseUrl}/open-apis/authen/v1/authorize?client_id=${appId}&redirect_uri=${encodeURIComponent(redirect_uri)}&scope=${scope}&state=${state}`;
   }
-} 
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -29,6 +29,7 @@ export interface FeishuConfig {
   appId: string;
   appSecret: string;
   baseUrl: string;
+  authBaseUrl: string; // 授权页面基础URL，默认 https://accounts.feishu.cn
   authType: 'tenant' | 'user';
   tokenEndpoint: string;
   enableScopeValidation: boolean; // 是否启用权限检查
@@ -146,6 +147,10 @@ export class Config {
           type: 'string',
           description: '飞书API基础URL'
         },
+        'feishu-auth-base-url': {
+          type: 'string',
+          description: '飞书授权页面基础URL，默认 https://accounts.feishu.cn'
+        },
         'cache-enabled': {
           type: 'boolean',
           description: '是否启用缓存'
@@ -214,6 +219,7 @@ export class Config {
       appId: '',
       appSecret: '',
       baseUrl: 'https://open.feishu.cn/open-apis',
+      authBaseUrl: 'https://accounts.feishu.cn', // 默认飞书授权页面域名
       authType: 'tenant', // 默认
       tokenEndpoint: `http://127.0.0.1:${serverConfig.port}/getToken`, // 默认动态端口
       enableScopeValidation: true, // 默认启用权限检查
@@ -247,6 +253,17 @@ export class Config {
       this.configSources['feishu.baseUrl'] = ConfigSource.ENV;
     } else {
       this.configSources['feishu.baseUrl'] = ConfigSource.DEFAULT;
+    }
+
+    // 处理Auth Base URL（授权页面域名）
+    if (argv['feishu-auth-base-url']) {
+      feishuConfig.authBaseUrl = argv['feishu-auth-base-url'];
+      this.configSources['feishu.authBaseUrl'] = ConfigSource.CLI;
+    } else if (process.env.FEISHU_AUTH_BASE_URL) {
+      feishuConfig.authBaseUrl = process.env.FEISHU_AUTH_BASE_URL;
+      this.configSources['feishu.authBaseUrl'] = ConfigSource.ENV;
+    } else {
+      this.configSources['feishu.authBaseUrl'] = ConfigSource.DEFAULT;
     }
 
     // 处理authType


### PR DESCRIPTION
认证地址硬编码为`https://accounts.feishu.cn`，需要增加飞书认证地址配置项，以适配国际版飞书以及企业自建飞书服务