### PR TITLE
feat: 支持 Bearer Token 认证配置

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ FEISHU_ENABLED_MODULES=document
 # 服务器配置
 PORT=3333
 
+# MCP Bearer Token 认证（可选）
+# 设置后，所有 HTTP/SSE 端点将要求请求头 Authorization: Bearer <token>
+# 未设置时不启用认证（向后兼容）
+# 建议使用随机且复杂的字符串（如 UUID），避免使用简单可预测的值
+# MCP_BEARER_TOKEN=
+
 # 日志配置
 LOG_LEVEL=info
 LOG_SHOW_TIMESTAMP=true

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ feishu-tool create_feishu_document '{"title": "测试文档"}'
 | `FEISHU_ENABLED_MODULES` | ❌ | 启用模块：`document`、`task`、`calendar`、`member`、`all`。task/calendar/member 需 user 认证 | `document` |
 | `FEISHU_USER_KEY` | ❌ | `stdio` 模式的用户标识，可通过命令行参数 `--user-key` 覆盖 | `stdio` |
 | `FEISHU_ENCRYPTION_KEY` | ❌ | Token缓存敏感字段加密密钥。任意字符串，系统自动通过SHA-256派生加密密钥。设置后 `access_token`、`refresh_token`、`client_secret` 等敏感字段将被加密存储。Docker部署时建议设置固定密钥 | - |
+| `MCP_BEARER_TOKEN` | ❌ | MCP Bearer Token 认证令牌。设置后，所有 HTTP/SSE/StreamableHTTP 端点将要求请求头 `Authorization: Bearer <token>`，未设置时不启用认证。建议使用 UUID 等随机字符串 | - |
 
 ### 功能模块说明
 
@@ -286,6 +287,31 @@ feishu-tool create_feishu_document '{"title": "测试文档"}'
     }
   }
 }
+```
+
+#### Bearer Token 认证（可选）
+
+当配置了 `MCP_BEARER_TOKEN` 环境变量后，所有 HTTP/SSE/StreamableHTTP 端点将要求请求携带 `Authorization: Bearer <token>` 头。适用于公网部署场景，防止未授权访问。
+
+**配置示例**：
+
+```env
+# .env 文件
+MCP_BEARER_TOKEN=your-secret-token-here
+```
+
+**客户端配置示例（SSE 模式 + Bearer 认证）**：
+
+> ⚠️ 目前大多数 MCP 客户端（如 Cursor、Cline）不支持在 SSE/StreamableHTTP 连接中自定义请求头。如需使用 Bearer 认证，请确认你的客户端支持传递 `Authorization` 头，或通过反向代理（如 Nginx）在服务端前置认证。
+
+对于支持自定义头的客户端或 API 调用：
+
+```bash
+# SSE 连接示例
+curl -H "Authorization: Bearer your-secret-token-here" http://localhost:3333/sse?userKey=123456
+
+# StreamableHTTP 请求示例
+curl -X POST -H "Authorization: Bearer your-secret-token-here" -H "Content-Type: application/json" http://localhost:3333/mcp?userKey=123456
 ```
 
 **⚠️ 重要提示** : URL 中的 `userKey` 表示连接用户的标识，是非常重要的配置，请填写并尽可能随机

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
       - FEISHU_BASE_URL=${FEISHU_BASE_URL:-https://open.feishu.cn/open-apis}
       - FEISHU_AUTH_TYPE=${FEISHU_AUTH_TYPE:-tenant}
       - PORT=${PORT:-3333}
+      - MCP_BEARER_TOKEN=${MCP_BEARER_TOKEN:-}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - CACHE_ENABLED=${CACHE_ENABLED:-true}
       - CACHE_TTL=${CACHE_TTL:-300}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from 'express';
+import express, { Request, Response, NextFunction } from 'express';
 import { Server } from 'http';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
@@ -10,6 +10,7 @@ import { SSEConnectionManager } from './manager/sseConnectionManager.js';
 import { FeishuMcp } from './mcp/feishuMcp.js';
 import { callback} from './services/callbackService.js';
 import { UserAuthManager, UserContextManager, getBaseUrl ,TokenCacheManager, TokenRefreshManager } from './utils/auth/index.js';
+import { Config } from './utils/config.js';
 
 export class FeishuMcpServer {
   private connectionManager: SSEConnectionManager;
@@ -69,6 +70,72 @@ export class FeishuMcpServer {
     }
   }
 
+  /**
+   * Bearer Token 认证中间件
+   * 如果配置了 MCP_BEARER_TOKEN，则验证请求的 Authorization 头
+   * 未配置时跳过认证（向后兼容）
+   */
+  private bearerAuthMiddleware(req: Request, res: Response, next: NextFunction): void {
+    const config = Config.getInstance();
+    const bearerToken = config.server.bearerToken;
+
+    // 未配置 bearer token 时跳过认证
+    if (!bearerToken) {
+      next();
+      return;
+    }
+
+    // 从 Authorization 头提取 token（Express 可能返回 string 或 string[]）
+    const authHeaderRaw = req.headers['authorization'];
+    if (!authHeaderRaw) {
+      Logger.warn(`[Bearer Auth] 请求缺少 Authorization 头: ${req.method} ${req.url}`);
+      res.status(401).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32001,
+          message: 'Unauthorized: Missing Authorization header. Provide Authorization: Bearer <token>',
+        },
+        id: null,
+      });
+      return;
+    }
+
+    // 处理可能为数组的情况，取第一个值
+    const authHeader = Array.isArray(authHeaderRaw) ? authHeaderRaw[0] : authHeaderRaw;
+
+    // 验证 Bearer token 格式和值（RFC 6750: Bearer 前缀大小写不敏感）
+    const parts = authHeader.split(' ');
+    if (parts.length !== 2 || parts[0].toLowerCase() !== 'bearer') {
+      Logger.warn(`[Bearer Auth] Authorization 头格式错误: ${req.method} ${req.url}`);
+      res.status(401).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32001,
+          message: 'Unauthorized: Invalid Authorization header format. Expected: Bearer <token>',
+        },
+        id: null,
+      });
+      return;
+    }
+
+    const token = parts[1].trim();
+    if (token !== bearerToken) {
+      Logger.warn(`[Bearer Auth] Token 验证失败: ${req.method} ${req.url}, 请求token长度=${token.length}, 配置token长度=${bearerToken.length}`);
+      res.status(403).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32002,
+          message: 'Forbidden: Invalid bearer token',
+        },
+        id: null,
+      });
+      return;
+    }
+
+    // 认证通过
+    next();
+  }
+
   async startHttpServer(port: number): Promise<void> {
     const app = express();
 
@@ -76,6 +143,11 @@ export class FeishuMcpServer {
 
     // Parse JSON requests for the Streamable HTTP endpoint only, will break SSE endpoint
     app.use("/mcp", express.json());
+
+    // 对所有 MCP 相关端点应用 Bearer Token 认证中间件
+    app.use('/mcp', this.bearerAuthMiddleware.bind(this));
+    app.use('/sse', this.bearerAuthMiddleware.bind(this));
+    app.use('/messages', this.bearerAuthMiddleware.bind(this));
 
     app.post('/mcp', async (req, res) => {
       try {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -20,6 +20,7 @@ export enum ConfigSource {
  */
 export interface ServerConfig {
   port: number;
+  bearerToken: string; // MCP Bearer Token 认证，为空时不启用认证
 }
 
 /**
@@ -132,6 +133,10 @@ export class Config {
           type: 'number',
           description: '服务器监听端口'
         },
+        'bearer-token': {
+          type: 'string',
+          description: 'MCP Bearer Token 认证令牌，设置后所有 HTTP/SSE 端点将要求 Authorization: Bearer <token>'
+        },
         'log-level': {
           type: 'string',
           description: '日志级别 (debug, info, log, warn, error, none)'
@@ -197,6 +202,7 @@ export class Config {
   private initServerConfig(argv: any): ServerConfig {
     const serverConfig: ServerConfig = {
       port: 3333,
+      bearerToken: '',
     };
     
     // 处理PORT
@@ -209,6 +215,18 @@ export class Config {
     } else {
       this.configSources['server.port'] = ConfigSource.DEFAULT;
     }
+
+    // 处理 Bearer Token（trim 去除空白字符，stripQuotes 去除环境变量中可能的引号包裹）
+    if (argv['bearer-token']) {
+      serverConfig.bearerToken = this.stripQuotes(argv['bearer-token'].trim());
+      this.configSources['server.bearerToken'] = ConfigSource.CLI;
+    } else if (process.env.MCP_BEARER_TOKEN) {
+      serverConfig.bearerToken = this.stripQuotes(process.env.MCP_BEARER_TOKEN.trim());
+      this.configSources['server.bearerToken'] = ConfigSource.ENV;
+    } else {
+      this.configSources['server.bearerToken'] = ConfigSource.DEFAULT;
+    }
+
     return serverConfig;
   }
   
@@ -479,6 +497,7 @@ export class Config {
     
     Logger.info('服务器配置:');
     Logger.info(`- 端口: ${this.server.port} (来源: ${this.configSources['server.port']})`);
+    Logger.info(`- Bearer Token 认证: ${this.server.bearerToken ? '已启用' : '未启用'} (来源: ${this.configSources['server.bearerToken']})`);
 
     Logger.info('飞书配置:');
     if (this.feishu.appId) {
@@ -536,6 +555,20 @@ export class Config {
 
   private normalizeBaseUrl(url: string): string {
     return url.replace(/\/+$/, '');
+  }
+
+  /**
+   * 去除字符串两端可能存在的引号包裹（单引号或双引号）
+   * Docker 环境变量和 .env 文件有时会将值用引号包裹
+   * @param value 原始字符串
+   * @returns 去除引号后的字符串
+   */
+  private stripQuotes(value: string): string {
+    if ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))) {
+      return value.slice(1, -1);
+    }
+    return value;
   }
   
   /**


### PR DESCRIPTION
## feat: 支持 Bearer Token 认证配置

### 功能概述
新增 `MCP_BEARER_TOKEN` 环境变量，支持对 HTTP/SSE/StreamableHTTP 端点配置 Bearer Token 认证，适用于公网部署场景防止未授权访问。

### 变更详情
- **环境变量**：新增 `MCP_BEARER_TOKEN`，未设置时不启用认证（向后兼容）
- **命令行参数**：新增 `--bearer-token`
- **认证请求头**：`Authorization: Bearer <token>`（RFC 6750，前缀大小写不敏感）
- **覆盖端点**：`/mcp`、`/sse`、`/messages`
- **配置读取**：trim 去除空白字符，stripQuotes 去除 Docker 环境变量中可能的引号包裹
- **认证失败响应**：缺少头 → 401，格式错误 → 401，token 不匹配 → 403

### 修改文件
- `.env.example` — 新增 MCP_BEARER_TOKEN 说明
- `src/utils/config.ts` — ServerConfig 新增 bearerToken 字段、stripQuotes 方法
- `src/server.ts` — 新增 bearerAuthMiddleware 中间件
- `README.md` — 环境变量表格和 Bearer 认证配置示例
- `docker-compose.yaml` — 新增 MCP_BEARER_TOKEN 环境变量传递