### PR TITLE
fix: print package version from main CLI

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const packageJson = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as {
+  version: string;
+};
+
+test('main CLI prints package version without starting the server', () => {
+  const result = spawnSync(process.execPath, ['dist/cli.js', '--version'], {
+    encoding: 'utf-8',
+  });
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stderr, '');
+  assert.equal(result.stdout.trim(), packageJson.version);
+});
+
+test('main CLI help still prints yargs usage metadata', () => {
+  const result = spawnSync(process.execPath, ['dist/cli.js', '--help'], {
+    encoding: 'utf-8',
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /--version/);
+  assert.match(result.stdout, /--feishu-app-id/);
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,17 @@
 #!/usr/bin/env node
 
 import { resolve } from "path";
+import { createRequire } from "module";
 import { config } from "dotenv";
 import { startServer } from "./index.js";
 import { Logger } from "./utils/logger.js";
+
+if (process.argv.includes("--version") || process.argv.includes("-v")) {
+  const require = createRequire(import.meta.url);
+  const packageJson = require("../package.json") as { version: string };
+  console.log(packageJson.version);
+  process.exit(0);
+}
 
 // Load .env from the current working directory
 config({ path: resolve(process.cwd(), ".env") });


### PR DESCRIPTION
## Summary
- Handle `feishu-mcp --version` / `-v` before starting the server.
- Print the package version from `package.json` instead of letting yargs infer `unknown`.
- Add focused CLI metadata tests for `--version` and `--help`.

## Reproduction against published package
```sh
npm exec --yes --package=feishu-mcp@0.3.2 -- feishu-mcp --version
# unknown
```

## Verification
```sh
.\node_modules\.bin\tsc.cmd
.\node_modules\.bin\tsc-alias.cmd
node --test dist/cli.test.js
node dist/cli.js --version
npm exec --yes --package=feishu-mcp@0.3.2 -- feishu-mcp --version
git diff --check
```

The patched CLI prints `0.3.3`; the published package still prints `unknown`.